### PR TITLE
Last model version and best performing from last validation epoch

### DIFF
--- a/train_precip_lightning.py
+++ b/train_precip_lightning.py
@@ -30,10 +30,16 @@ def train_regression(hparams, find_batch_size_automatically: bool = False):
         dirpath=default_save_path / net.__class__.__name__,
         filename=net.__class__.__name__ + "_rain_threshold_50_{epoch}-{val_loss:.6f}",
         save_top_k=1,
-        save_last=True,
         verbose=False,
         monitor="val_loss",
         mode="min",
+    )
+
+    last_checkpoint_callback = ModelCheckpoint(
+        dirpath=default_save_path / net.__class__.__name__,
+        filename=net.__class__.__name__ + "_rain_threshold_50_{epoch}-{val_loss:.6f}_last",
+        save_top_k=1,
+        verbose=False,
     )
     
     lr_monitor = LearningRateMonitor()
@@ -51,7 +57,7 @@ def train_regression(hparams, find_batch_size_automatically: bool = False):
         max_epochs=hparams.epochs,
         default_root_dir=default_save_path,
         logger=tb_logger,
-        callbacks=[checkpoint_callback, earlystopping_callback, lr_monitor],
+        callbacks=[checkpoint_callback, last_checkpoint_callback, earlystopping_callback, lr_monitor],
         val_check_interval=hparams.val_check_interval,
     )
 

--- a/train_precip_lightning.py
+++ b/train_precip_lightning.py
@@ -29,11 +29,13 @@ def train_regression(hparams, find_batch_size_automatically: bool = False):
     checkpoint_callback = ModelCheckpoint(
         dirpath=default_save_path / net.__class__.__name__,
         filename=net.__class__.__name__ + "_rain_threshold_50_{epoch}-{val_loss:.6f}",
-        save_top_k=-1,
+        save_top_k=1,
+        save_last=True,
         verbose=False,
         monitor="val_loss",
         mode="min",
     )
+    
     lr_monitor = LearningRateMonitor()
     tb_logger = loggers.TensorBoardLogger(save_dir=default_save_path, name=net.__class__.__name__)
 


### PR DESCRIPTION
Works flawless, but saves the last epoch as `last.ckpt`. I personally think it is not meaningful. So I would rather create a new checkpoint that saves the last one and gives the name (val_loss, epoch, "last").

What do you think?

Something like this:

```
    last_checkpoint_callback = ModelCheckpoint(
        save_last=True,
        dirpath=default_save_path / net.__class__.__name__,
        filename=net.__class__.__name__ + "_rain_threshold_50_{epoch}-{val_loss:.6f}_last",
        verbose=False,
    )
```